### PR TITLE
Fixed copyright year typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2021 XYZ, Inc._


### PR DESCRIPTION
Changed copyright year from 2022 to 2021
Signed-off-by: bashgame <amen.kester@gmail.com>