### PR TITLE
Fixed typo in footer of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2021 XYZ, Inc._


### PR DESCRIPTION
Hello, I made a change to the footer of the README.md file to fix a typo. The original footer said '© 2022 XYZ, Inc.' but it should be '© 2021 XYZ, Inc.' I believe this is an important change to make because it ensures that the copyright information is accurate. Thank you for reviewing my pull request.