### PR TITLE
fix the typo in the year at footnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2021 XYZ, Inc._


### PR DESCRIPTION
fix the typo in the year at the footnote during the Git course