### PR TITLE
Changing the copyright year in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2021 XYZ, Inc._


### PR DESCRIPTION
There was a typo in the copyright year.  Hence, updating from copyright year in footer from 2022 to 2021.