### PR TITLE
Fix typo in copyright message

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2021 XYZ, Inc._


### PR DESCRIPTION
Change `© 2022 XYZ, Inc.` to `© 2021 XYZ, Inc.`