### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+頲021 XYZ, Inc.


### PR DESCRIPTION
In this pull request, I've addressed a small typo in the README file.

The footer previously read: "頲022 XYZ, Inc.", and it has been corrected to: "頲021 XYZ, Inc.". 