### PR TITLE
fix typo - readme copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2021 XYZ, Inc._


### PR DESCRIPTION
## Merge Request

Fixed typo in the readme file - changed the footer `copyright` year from `2022` to `2021`