### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Fix Typo in README.md:
In the task, a typo was identified in the README.md file where the footer read "2022 XYZ, Inc." instead of the correct "2023 XYZ, Inc." This PR fixes that typo by updating the text to "2023 XYZ, Inc."

Changes Made:

Fixed the typo in the README.md footer, updating it to "2023 XYZ, Inc."