### PR TITLE
Update Copyright Year to 2023 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This pull request updates the copyright year from 2022 to 2023 in the README.md file to reflect the current year.

### Changes:
- Modified the copyright footer in the README.md to say "© 2023 XYZ, Inc." instead of "© 2022 XYZ, Inc."

This change is intended to keep the copyright information up to date and accurate for 2023.

Please review the change and merge it if everything is in order. Thank you!
