### PR TITLE
Revert "Fix typo in footer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This pull request reverts the previous change made in the "bug-fix-typo" branch that fixed a typo in the footer of the README.md file. The original content, "2022 XYZ, Inc.", has been restored to the file.

The following is a screenshot showing the current branch and successful merge operation with the file that has changed :
<img width="506" alt="merge_branches" src="https://github.com/ibm-developer-skills-network/jbbmo-Introduction-to-Git-and-GitHub/assets/113260328/89376b54-c975-4ea8-884c-597895e9876e">
