### PR TITLE
Revert the footer year in README.md to 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2024 XYZ, Inc._


### PR DESCRIPTION
The footer year was incorrectly updated to 2022 in a previous commit. To correct this error and align with the original documentation, we are reverting the footer year to 2024. This ensures that the information in the README.md remains accurate and consistent with previous versions of the file.