### PR TITLE
Revert typo fix in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/close_pr.yml
+++ b/.github/ISSUE_TEMPLATE/close_pr.yml
@@ -1,0 +1,14 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        # Optional. Post a issue comment just before closing a pull request.
+        comment: "Congratulations! You have completed the lab. Closing for maintainence purpose."

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._


### PR DESCRIPTION
This pull request reverts the typo fix in the README.md file from the bug-fix-typo branch, changing it back to "2022 XYZ, Inc.