### PR TITLE
Revert "Fixed typo in footer of README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This pull request reverts the previous commit that changed the footer of the README file from "2022" to "2023". 
The footer should reflect the correct year, which is "2022".
