### PR TITLE
Bug fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Exclude file .DS_Store for Mac OS users
+.DS_Store
+ 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2024 XYZ, Inc._


### PR DESCRIPTION
changed some text from README.MD, i.e. 2022 XYZ to 2024 XYZ
added .DS_Store (Mac OS-specific files) to .gitignore (for Mac OS users)