### PR TITLE
Fixed copyright typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
In README.md, changed footer copyright from "2022" to "2023".