### PR TITLE
Reverted footer year change: 2023 to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc.
+_

--- a/README.md
+++ b/README.md
@@ -13,15 +13,5 @@ Output
    simple interest = p*t*r
 ```
 
-<<<<<<< HEAD
 _© 2023 XYZ, Inc.
 _
-=======
-_© 2023 XYZ, Inc._
->>>>>>> e212255 (Fixed typo in README footer: Updated 2022 to 2023)
-<<<<<<< HEAD
-2022 XYZ, Inc.
-=======
-2023 XYZ, Inc.
->>>>>>> e212255...
-

--- a/README.md
+++ b/README.md
@@ -13,5 +13,15 @@ Output
    simple interest = p*t*r
 ```
 
+<<<<<<< HEAD
 _© 2023 XYZ, Inc.
 _
+=======
+_© 2023 XYZ, Inc._
+>>>>>>> e212255 (Fixed typo in README footer: Updated 2022 to 2023)
+<<<<<<< HEAD
+2022 XYZ, Inc.
+=======
+2023 XYZ, Inc.
+>>>>>>> e212255...
+


### PR DESCRIPTION
Reverted the previous commit that changed the footer year from 2022 to 2023. Now it is back to 2022.