### PR TITLE
Fix typo in README footer: Update year to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Fix Typo in README Footer
Changes Made:
Updated the footer in README.md

Changed the year from 2022 to 2023

Reason for Change:
The footer contained an outdated year (2022).

Updated it to the correct year (2023) to reflect the latest version.