### PR TITLE
Updated footer year from 2022 to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Updates the copyright year in README.md to reflect the current year (2023).  
This ensures compliance with our documentation standards.

**Changes made**:  
- Before: `© 2022 XYZ, Inc.`  
- After: `© 2023 XYZ, Inc.`  