### PR TITLE
Fix typo in footer: change 2022 to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This reverts the footer change back to 2022 as originally intended.