### PR TITLE
Fix Typo in README.md Footer Year (2022 → 2023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This pull request updates the footer year in the README.md file from 2022 to 2023 to reflect the current year. This is part of the final project task to fix a typo.

Changes made:
- Updated: `2022 XYZ, Inc.` → `2023 XYZ, Inc.`
- 