### PR TITLE
Revert footer year back to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_2023 XYZ, Inc_


### PR DESCRIPTION
This pull request reverts the footer change from "2023 XYZ, Inc." back to "2022 XYZ, Inc." as part of the final Git CLI lab.