### PR TITLE
Fix year typo from 2022 to 2023 in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Submitting this PR as part of the lab to revert the footer year fix