### PR TITLE
Revert copyright year change from 2023 back to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This PR reverts the previous change that updated the copyright year from 2022 to 2023 in the README.md file footer.