### PR TITLE
fixed typo in README.md footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This PR reverts the previous fix where the typo in `README.md` was updated from "2022 XYZ, Inc." to "2023 XYZ, Inc."