### PR TITLE
Revert typo fix in README footer back to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This PR reverts the typo fix from 2023 back to 2022 in the README footer.