### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Fix typo: Update copyright year from 2022 to 2023

This commit updates the copyright year in the footer from 2022 to 2023 to reflect the current year.